### PR TITLE
Added tab/submit error scenarios

### DIFF
--- a/src/app/acPrototypeBot/dialogs/errors/ErrorAdminCard.ts
+++ b/src/app/acPrototypeBot/dialogs/errors/ErrorAdminCard.ts
@@ -1,0 +1,3 @@
+const ErrorAdminCard = require("./admin-config.json");
+
+export default ErrorAdminCard;

--- a/src/app/acPrototypeBot/dialogs/errors/ErrorInterviewCandidates.ts
+++ b/src/app/acPrototypeBot/dialogs/errors/ErrorInterviewCandidates.ts
@@ -1,0 +1,3 @@
+const ErrorInterviewCandidatesCard = require("./interview-candidates.json");
+
+export default ErrorInterviewCandidatesCard;

--- a/src/app/acPrototypeBot/dialogs/errors/ErrorManagerDashboard.ts
+++ b/src/app/acPrototypeBot/dialogs/errors/ErrorManagerDashboard.ts
@@ -1,0 +1,3 @@
+const ErrorManagerDashboardCard = require("./manager-dashboard.json");
+
+export default ErrorManagerDashboardCard;

--- a/src/app/acPrototypeBot/dialogs/errors/RecommendationsCard.ts
+++ b/src/app/acPrototypeBot/dialogs/errors/RecommendationsCard.ts
@@ -1,0 +1,4 @@
+// Card with tab/submit error scenarios
+const RecommendationCard = require("./recommendations.json");
+
+export default RecommendationCard;

--- a/src/app/acPrototypeBot/dialogs/errors/admin-config.json
+++ b/src/app/acPrototypeBot/dialogs/errors/admin-config.json
@@ -1,0 +1,194 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "bleed": true,
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Admin Dashboard",
+          "color": "Dark",
+          "fontType": "Default",
+          "size": "Large",
+          "weight": "Bolder"
+        }
+      ],
+      "spacing": "None"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Configure the Workday App",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Decide what features you want enabled/disabled",
+              "isSubtle": true,
+              "wrap": true,
+              "fontType": "Default",
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "Configure"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "wrap": true,
+              "text": "View Diagnostics"
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Troubleshooting a problem or needing to log out",
+              "isSubtle": true,
+              "weight": "Lighter",
+              "fontType": "Default",
+              "wrap": true
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "View diagnostics"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Disconnect from Workday",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "⚠️ Taking this action will sever all connections between Workday and Microsoft Teams for all of your users.",
+              "isSubtle": true,
+              "wrap": true,
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "Disconnect"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Innovation Services Agreement",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Status: ENABLED\nCredentials: Logan McNeil (CHRO, HRExe, Mgr 4000, MatMgr, ProMgr,TalMgr,VPRept)",
+              "isSubtle": true,
+              "wrap": true,
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "auto",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "Use my credentials"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "TextBlock",
+      "wrap": true
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.3"
+}

--- a/src/app/acPrototypeBot/dialogs/errors/interview-candidates.json
+++ b/src/app/acPrototypeBot/dialogs/errors/interview-candidates.json
@@ -1,0 +1,289 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "bleed": true,
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Interview Candidates | 5 candidates",
+          "weight": "Bolder",
+          "size": "large"
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Peter Smith",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Software Engineer 2 | Bend, Oregon",
+              "isSubtle": true,
+              "wrap": true,
+              "fontType": "Default",
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Small"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/women/31.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "wrap": true,
+              "text": "Marie Beaudoin"
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Senior Product Manager | Boulder, Colorado",
+              "isSubtle": true,
+              "weight": "Lighter",
+              "fontType": "Default"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/women/40.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Susan Shammas",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Design Manager | Vancouver, British Columbia",
+              "isSubtle": true,
+              "wrap": true,
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/men/40.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Aaron Buxton",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Senior Software Engineer | Bend, Oregon",
+              "isSubtle": true,
+              "wrap": true,
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/men/3.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "John Barry",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "Design Manager | Seattle, Washington",
+              "isSubtle": true,
+              "wrap": true,
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.2"
+}

--- a/src/app/acPrototypeBot/dialogs/errors/manager-dashboard.json
+++ b/src/app/acPrototypeBot/dialogs/errors/manager-dashboard.json
@@ -1,0 +1,182 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "bleed": true,
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Manager Dashboard | 3 employees",
+          "weight": "Bolder",
+          "size": "Large"
+        }
+      ]
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/women/32.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Gunashree R V",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "🎉   5 year anniversary this week",
+              "isSubtle": true,
+              "wrap": true,
+              "fontType": "Default",
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Small"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/women/36.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "wrap": true,
+              "text": "Anoop Dhillon"
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "📅  Upcoming time off: Mar 20-25, Apr 1",
+              "isSubtle": true,
+              "weight": "Lighter",
+              "fontType": "Default"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    },
+    {
+      "type": "ColumnSet",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "Image",
+              "style": "Person",
+              "url": "https://randomuser.me/api/portraits/women/40.jpg",
+              "size": "Small"
+            }
+          ],
+          "width": "auto"
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "text": "Amol Dumrewal",
+              "wrap": true
+            },
+            {
+              "type": "TextBlock",
+              "spacing": "None",
+              "text": "🎂  Birthday this week",
+              "isSubtle": true,
+              "wrap": true,
+              "weight": "Lighter"
+            }
+          ],
+          "width": "stretch"
+        },
+        {
+          "type": "Column",
+          "width": "50px",
+          "items": [
+            {
+              "type": "ActionSet",
+              "actions": [
+                {
+                  "type": "Action.Submit",
+                  "title": "..."
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "separator": true,
+      "spacing": "Medium"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.2"
+}

--- a/src/app/acPrototypeBot/dialogs/errors/recommendations.json
+++ b/src/app/acPrototypeBot/dialogs/errors/recommendations.json
@@ -1,0 +1,104 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Recommendations from Workday",
+      "wrap": true,
+      "size": "Large",
+      "weight": "Bolder"
+    },
+    {
+      "items": [
+        {
+          "text": "Here are some quick links that might be helpful.",
+          "wrap": true,
+          "spacing": "default",
+          "type": "TextBlock"
+        }
+      ],
+      "type": "Container"
+    }
+  ],
+  "actions": [
+    {
+      "data": {
+        "shouldSetHTTPError": true
+      },
+      "title": "Lookup a coworker",
+      "type": "Action.Submit"
+    },
+    {
+      "data": {
+        "shouldSetEmptyResponse": true
+      },
+      "title": "Take time off",
+      "type": "Action.Submit"
+    },
+    {
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "text": "Please upload a photo of your receipt below including a brief description. If you want to manually enter a Quick Expense, type **manual**.",
+            "wrap": true,
+            "spacing": "default",
+            "type": "TextBlock"
+          }
+        ],
+        "version": "1.0.0"
+      },
+      "title": "Enter expense",
+      "type": "Action.ShowCard"
+    },
+    {
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "items": [
+              {
+                "text": "**What is Ask Workday?** ✨",
+                "wrap": true,
+                "spacing": "default",
+                "type": "TextBlock"
+              },
+              {
+                "text": "Type questions or keywords to quickly get to info in Workday.",
+                "wrap": true,
+                "spacing": "None",
+                "type": "TextBlock"
+              },
+              {
+                "text": "",
+                "wrap": true,
+                "spacing": "default",
+                "type": "TextBlock"
+              }
+            ],
+            "type": "Container"
+          }
+        ],
+        "version": "1.2"
+      },
+      "title": "Ask Workday",
+      "type": "Action.ShowCard"
+    },
+    {
+      "data": {
+        "shouldSetMalformedTab": true
+      },
+      "title": "Company holidays",
+      "type": "Action.Submit"
+    },
+    {
+      "data": {
+        "shouldSetMalformedCard": true
+      },
+      "title": "More...",
+      "type": "Action.Submit"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.2"
+}


### PR DESCRIPTION
Adding error scenarios for tab/submit actions in a new tab with entityId: **`error_tab`**:

1. tab/submit with 200 OK and empty response body.
2. tab/submit with !200 OK (Error code: 430).
3. tab/submit with 200 OK and malformed tab response.
4. tab/submit with 200 OK and malformed adaptive card responses.